### PR TITLE
Change char enum values to be positive

### DIFF
--- a/wasserstein/internal/EMDUtils.hh
+++ b/wasserstein/internal/EMDUtils.hh
@@ -62,7 +62,7 @@
 
 // default namespace macros
 #ifndef BEGIN_WASSERSTEIN_NAMESPACE
-# define WASSERSTEIN_NAMESPACE wasserstein
+# define WASSERSTEIN_NAMESPACE emd
 # define BEGIN_WASSERSTEIN_NAMESPACE namespace WASSERSTEIN_NAMESPACE {
 # define END_WASSERSTEIN_NAMESPACE }
 #endif


### PR DESCRIPTION
With my setup (details below), the library refuses to compile due to the value `-1` being "`outside the range of underlying type ‘char’`" for the `ArcState` and `ExtraParticle` enums. Is there any reason we can't use non-negative values for these enums? If I haven't missed some reason this doesn't make sense, the small changes in this PR should make the library compatible with more systems with no downsides. 

The system I'm trying to compile this on is:
architecture: `ppc64le`
os: `Red Hat Enterprise Linux 8.3 (Ootpa)`
compiler: `gcc (GCC) 8.3.1 20191121 (Red Hat 8.3.1-5)`