### PR TITLE
Positive enum values

### DIFF
--- a/wasserstein/internal/EMDUtils.hh
+++ b/wasserstein/internal/EMDUtils.hh
@@ -132,7 +132,7 @@ enum class EMDStatus : char {
 };
 
 enum class ExtraParticle : char {
-  Neither = -1,
+  Neither = 2,
   Zero = 0,
   One = 1
 };

--- a/wasserstein/internal/NetworkSimplex.hh
+++ b/wasserstein/internal/NetworkSimplex.hh
@@ -294,7 +294,7 @@ private:
 
   // State constants for arcs
   enum ArcState : char {
-    STATE_UPPER = -1,
+    STATE_UPPER = 2,
     STATE_TREE  =  0,
     STATE_LOWER =  1
   };


### PR DESCRIPTION
(NB this is a duplicate of a previous PR that I accidentally made from the wrong branch of my fork)

With my setup (details below), the library refuses to compile due to the value -1 being "outside the range of underlying type ‘char’" for the ArcState and ExtraParticle enums. I don't understand why this happens, but it is fixed by using non-negative values for all enum fields. Is there any reason we can't use non-negative values for these enums? If I haven't missed some reason this doesn't make sense, the small changes in this PR should make the library compatible with more systems with no downsides.

The system I'm trying to compile this on is:
architecture: ppc64le
os: Red Hat Enterprise Linux 8.3 (Ootpa)
compiler: gcc (GCC) 8.3.1 20191121 (Red Hat 8.3.1-5)
