### PR TITLE
fix: Use signed char to avoid compiler error

### DIFF
--- a/wasserstein/internal/EMDUtils.hh
+++ b/wasserstein/internal/EMDUtils.hh
@@ -131,7 +131,7 @@ enum class EMDStatus : char {
   Infeasible = 5
 };
 
-enum class ExtraParticle : char {
+enum class ExtraParticle : signed char {
   Neither = -1,
   Zero = 0,
   One = 1

--- a/wasserstein/internal/NetworkSimplex.hh
+++ b/wasserstein/internal/NetworkSimplex.hh
@@ -293,7 +293,7 @@ private:
   //---------------------------------------------------------------------------
 
   // State constants for arcs
-  enum ArcState : char {
+  enum ArcState : signed char {
     STATE_UPPER = -1,
     STATE_TREE  =  0,
     STATE_LOWER =  1


### PR DESCRIPTION
* Resolves #3 
* Closes #4

Under arm64 architectures the use of a negative char results in an error of

> error: enumerator value ‘-1’ is outside the range of underlying type ‘char’

At the request of the project maintainer, use a `signed char` instead of changing the values of the enum.